### PR TITLE
Add TTS

### DIFF
--- a/src/components/phrase-def.tsx
+++ b/src/components/phrase-def.tsx
@@ -4,6 +4,7 @@ import { ArrowUpIcon, HeadphonesIcon, TrashIcon } from 'lucide-react'
 import { languageLabels } from '~/lib/i18n-helpers'
 import { getTimeAgo } from '~/lib/dates'
 import { useVoices } from '~/hooks/use-voices'
+import { useState } from 'react'
 
 export function PhraseDef({
   def: { def, phrase, timestamp },
@@ -15,6 +16,8 @@ export function PhraseDef({
   onMoveUp: VoidFunction
 }) {
   const voices = useVoices()
+  const [isSpeaking, setIsSpeaking] = useState<number>()
+
   return (
     <div>
       <div
@@ -27,7 +30,7 @@ export function PhraseDef({
         <p className="text-sm text-gray-500">{getTimeAgo(timestamp)}</p>
       </div>
       <div className="flex flex-col gap-2">
-        {def.translations.map(t => {
+        {def.translations.map((t, i) => {
           const labels = languageLabels[t.target]
           const isRtl = t.target === 'ar-SA'
 
@@ -44,6 +47,8 @@ export function PhraseDef({
             }
 
             utterance.lang = t.target
+            utterance.onstart = () => setIsSpeaking(i)
+            utterance.onend = () => setIsSpeaking(undefined)
             window.speechSynthesis.speak(utterance)
           }
           return (
@@ -52,12 +57,23 @@ export function PhraseDef({
               className="flex flex-col gap-2 rounded-md border p-2 shadow"
               data-lang={t.target}
             >
-              <span className="font-bold data-[rtl=true]:text-right" data-rtl={isRtl}>
-                {labels.flag} {t.text}
-              </span>
-              <Button variant="outline" size="icon" className="rounded-full" onClick={speak}>
-                <HeadphonesIcon />
-              </Button>
+              <div
+                className="flex items-center gap-2 data-[rtl=true]:flex-row-reverse"
+                data-rtl={isRtl}
+              >
+                <Button
+                  variant="outline"
+                  size="icon"
+                  className="rounded-full disabled:animate-spin"
+                  onClick={speak}
+                  disabled={isSpeaking === i}
+                >
+                  <HeadphonesIcon />
+                </Button>
+                <span className="font-bold data-[rtl=true]:text-right" data-rtl={isRtl}>
+                  {labels.flag} {t.text}
+                </span>
+              </div>
               <p className="text-sm data-[rtl=true]:text-right" data-rtl={isRtl}>
                 {t.definition}
               </p>

--- a/src/components/phrase-def.tsx
+++ b/src/components/phrase-def.tsx
@@ -1,8 +1,9 @@
 import type { Phrase } from '~/lib/types'
 import { Button } from './ui/button'
-import { ArrowUpIcon, TrashIcon } from 'lucide-react'
+import { ArrowUpIcon, HeadphonesIcon, TrashIcon } from 'lucide-react'
 import { languageLabels } from '~/lib/i18n-helpers'
 import { getTimeAgo } from '~/lib/dates'
+import { useVoices } from '~/hooks/use-voices'
 
 export function PhraseDef({
   def: { def, phrase, timestamp },
@@ -13,6 +14,7 @@ export function PhraseDef({
   onDelete: VoidFunction
   onMoveUp: VoidFunction
 }) {
+  const voices = useVoices()
   return (
     <div>
       <div
@@ -28,6 +30,22 @@ export function PhraseDef({
         {def.translations.map(t => {
           const labels = languageLabels[t.target]
           const isRtl = t.target === 'ar-SA'
+
+          function speak() {
+            const utterance = new SpeechSynthesisUtterance(t.text)
+
+            if (t.target === 'ar-SA') {
+              utterance.voice = voices.find(v => v.lang.startsWith('ar')) ?? null
+            } else if (t.target !== 'en-US') {
+              utterance.voice =
+                voices.find(v => v.lang === t.target && v.localService) ??
+                voices.find(v => v.lang === t.target) ??
+                null
+            }
+
+            utterance.lang = t.target
+            window.speechSynthesis.speak(utterance)
+          }
           return (
             <div
               key={t.target}
@@ -37,6 +55,9 @@ export function PhraseDef({
               <span className="font-bold data-[rtl=true]:text-right" data-rtl={isRtl}>
                 {labels.flag} {t.text}
               </span>
+              <Button variant="outline" size="icon" className="rounded-full" onClick={speak}>
+                <HeadphonesIcon />
+              </Button>
               <p className="text-sm data-[rtl=true]:text-right" data-rtl={isRtl}>
                 {t.definition}
               </p>

--- a/src/hooks/use-voices.ts
+++ b/src/hooks/use-voices.ts
@@ -1,0 +1,32 @@
+'use client'
+import { useEffect, useState } from 'react'
+
+export function useVoices(): SpeechSynthesisVoice[]
+export function useVoices(voiceName: string): SpeechSynthesisVoice | undefined
+export function useVoices(
+  voiceName?: string
+): SpeechSynthesisVoice[] | SpeechSynthesisVoice | undefined {
+  const [voices, setVoices] = useState<SpeechSynthesisVoice[]>([])
+
+  useEffect(() => {
+    function updateVoices() {
+      const availableVoices = window.speechSynthesis.getVoices()
+      setVoices(availableVoices)
+    }
+
+    // Some browsers load voices asynchronously
+    if (window.speechSynthesis.onvoiceschanged !== undefined) {
+      window.speechSynthesis.onvoiceschanged = updateVoices
+    }
+
+    updateVoices()
+  }, [])
+
+  // If a voice name is provided, return the specific voice
+  if (voiceName) {
+    return voices.find(voice => voice.name === voiceName)
+  }
+
+  // Otherwise return all voices
+  return voices
+}

--- a/src/hooks/use-voices.ts
+++ b/src/hooks/use-voices.ts
@@ -20,6 +20,13 @@ export function useVoices(
     }
 
     updateVoices()
+
+    // Cleanup function to remove the event handler when component unmounts
+    return () => {
+      if (window.speechSynthesis.onvoiceschanged !== undefined) {
+        window.speechSynthesis.onvoiceschanged = null
+      }
+    }
   }, [])
 
   // If a voice name is provided, return the specific voice

--- a/src/server/schema.ts
+++ b/src/server/schema.ts
@@ -13,9 +13,7 @@ export const geminiConfig = {
     properties: {
       detectedLang: {
         type: Schema.STRING,
-        enum: LANGS,
-        description:
-          'The ISO language code of the automatically detected source language (e.g., "en-US", "fr-FR")',
+        description: 'The most likely ISO language code of the phrase (e.g., "en-US", "fr-FR")',
         nullable: false,
       },
       translations: {


### PR DESCRIPTION
This pull request introduces a text-to-speech feature for translations and updates related components to support it. It includes the addition of a `useVoices` hook, modifications to the `PhraseDef` component to integrate speech synthesis, and a minor schema description update.

### Text-to-Speech Integration:

* **Added `useVoices` hook**: A custom hook (`src/hooks/use-voices.ts`) was created to manage and retrieve available speech synthesis voices, including support for dynamically loading voices in some browsers.
* **Enhanced `PhraseDef` component**: Integrated a text-to-speech button for each translation in the `PhraseDef` component. This includes logic to select appropriate voices based on the target language and to handle playback state. [[1]](diffhunk://#diff-9d1fd458d1167699d5160bb6cc49d6f408ae624bafce26e8b882a86245f8a479L3-R7) [[2]](diffhunk://#diff-9d1fd458d1167699d5160bb6cc49d6f408ae624bafce26e8b882a86245f8a479R18-R20) [[3]](diffhunk://#diff-9d1fd458d1167699d5160bb6cc49d6f408ae624bafce26e8b882a86245f8a479L28-R76)

### Minor Updates:

* **Updated schema description**: Revised the `detectedLang` property description in `src/server/schema.ts` to clarify its purpose as the most likely ISO language code.